### PR TITLE
Move play info fields to toolbar

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -882,23 +882,6 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
           </select>
         </aside>
 
-        <aside className="bg-gray-800 p-4 rounded">
-          <h2 className="text-lg font-bold mb-2">Play Info</h2>
-          <input
-            type="text"
-            value={playName}
-            onChange={(e) => setPlayName(e.target.value)}
-            placeholder="Play Name"
-            className="w-full p-1 rounded text-white bg-gray-700 mb-2"
-          />
-          <input
-            type="text"
-            value={playTags}
-            onChange={(e) => setPlayTags(e.target.value)}
-            placeholder="Tags (comma-separated)"
-            className="w-full p-1 rounded text-white bg-gray-700"
-          />
-        </aside>
 
         </div>
       </main>
@@ -912,6 +895,10 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
             onShare={handleShare}
             onSave={handleSave}
             onSaveAs={handleSaveAs}
+            playName={playName}
+            onPlayNameChange={setPlayName}
+            playTags={playTags}
+            onPlayTagsChange={setPlayTags}
           />
         </div>
       </div>

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -1,7 +1,18 @@
 import React, { useState } from 'react';
 import { PlusCircle, RotateCcw, Download, Share as ShareIcon, Save, FilePlus } from 'lucide-react';
 
-const Toolbar = ({ onNewPlay, onUndo, onExport, onShare, onSave, onSaveAs }) => {
+const Toolbar = ({
+  onNewPlay,
+  onUndo,
+  onExport,
+  onShare,
+  onSave,
+  onSaveAs,
+  playName,
+  onPlayNameChange,
+  playTags,
+  onPlayTagsChange,
+}) => {
   const [aspect, setAspect] = useState('1.333');
 
   const handleExportClick = () => {
@@ -19,7 +30,7 @@ const Toolbar = ({ onNewPlay, onUndo, onExport, onShare, onSave, onSaveAs }) => 
 
 
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap gap-2 items-center">
       <button
         className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
         onClick={onNewPlay}
@@ -48,6 +59,20 @@ const Toolbar = ({ onNewPlay, onUndo, onExport, onShare, onSave, onSaveAs }) => 
           <FilePlus className="w-4 h-4 mr-1" /> Save As
         </button>
       )}
+      <input
+        type="text"
+        value={playName}
+        onChange={(e) => onPlayNameChange && onPlayNameChange(e.target.value)}
+        placeholder="Play Name"
+        className="bg-gray-700 text-white p-1 rounded"
+      />
+      <input
+        type="text"
+        value={playTags}
+        onChange={(e) => onPlayTagsChange && onPlayTagsChange(e.target.value)}
+        placeholder="Tags"
+        className="bg-gray-700 text-white p-1 rounded"
+      />
       <div className="flex items-center gap-2">
         <select
           value={aspect}


### PR DESCRIPTION
## Summary
- integrate play name/tag inputs into `Toolbar`
- remove `Play Info` sidebar from `PlayEditor`
- wire new toolbar props from editor

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68486689d4448324970af28e70ce07a5