### PR TITLE
Move play info into toolbar

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -881,26 +881,6 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
             Add Note
           </button>
         </aside>
-
-
-        <aside className="bg-gray-800 p-4 rounded">
-          <h2 className="text-lg font-bold mb-2">Play Info</h2>
-          <input
-            type="text"
-            value={playName}
-            onChange={(e) => setPlayName(e.target.value)}
-            placeholder="Play Name"
-            className="w-full p-1 rounded text-white bg-gray-700 mb-2"
-          />
-          <input
-            type="text"
-            value={playTags}
-            onChange={(e) => setPlayTags(e.target.value)}
-            placeholder="Tags (comma-separated)"
-            className="w-full p-1 rounded text-white bg-gray-700"
-          />
-        </aside>
-
         </div>
       </main>
 
@@ -913,6 +893,10 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
             onShare={handleShare}
             onSave={handleSave}
             onSaveAs={handleSaveAs}
+            playName={playName}
+            playTags={playTags}
+            onPlayNameChange={setPlayName}
+            onPlayTagsChange={setPlayTags}
           />
         </div>
       </div>

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -1,7 +1,18 @@
 import React, { useState } from 'react';
 import { PlusCircle, RotateCcw, Download, Share as ShareIcon, Save, FilePlus } from 'lucide-react';
 
-const Toolbar = ({ onNewPlay, onUndo, onExport, onShare, onSave, onSaveAs }) => {
+const Toolbar = ({
+  onNewPlay,
+  onUndo,
+  onExport,
+  onShare,
+  onSave,
+  onSaveAs,
+  playName,
+  playTags,
+  onPlayNameChange,
+  onPlayTagsChange,
+}) => {
   const [aspect, setAspect] = useState('1.333');
 
   const handleExportClick = () => {
@@ -19,7 +30,7 @@ const Toolbar = ({ onNewPlay, onUndo, onExport, onShare, onSave, onSaveAs }) => 
 
 
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap gap-2 items-center">
       <button
         className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
         onClick={onNewPlay}
@@ -48,6 +59,21 @@ const Toolbar = ({ onNewPlay, onUndo, onExport, onShare, onSave, onSaveAs }) => 
           <FilePlus className="w-4 h-4 mr-1" /> Save As
         </button>
       )}
+
+      <input
+        type="text"
+        value={playName}
+        onChange={(e) => onPlayNameChange(e.target.value)}
+        placeholder="Play Name"
+        className="p-1 rounded bg-gray-700 text-white"
+      />
+      <input
+        type="text"
+        value={playTags}
+        onChange={(e) => onPlayTagsChange(e.target.value)}
+        placeholder="Tags"
+        className="p-1 rounded bg-gray-700 text-white"
+      />
       <div className="flex items-center gap-2">
         <select
           value={aspect}


### PR DESCRIPTION
## Summary
- show play name and tags inputs inside the bottom toolbar
- remove old Play Info sidebar section

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68486ec507608324b7236b20bdb509c6