### PR TITLE
Add lock and delete features to PlayLibrary

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -234,6 +234,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
           .filter((tag) => tag !== ''),
         image: dataURL,
         printImage: printURL,
+        locked: false,
       };
 
       await setDoc(
@@ -287,6 +288,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
           .filter((tag) => tag !== ''),
         image: dataURL,
         printImage: printURL,
+        locked: false,
       };
 
       await setDoc(


### PR DESCRIPTION
## Summary
- allow plays to be locked/unlocked and deleted from PlayLibrary
- include lock/unlock/delete controls on each play card
- default new plays to unlocked when saving

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684873a559688324b243155f781822aa