### PR TITLE
Add team selector dropdown

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,18 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { BrowserRouter as Router, Routes, Route, Link, useNavigate, useLocation } from 'react-router-dom';
-import { onAuthStateChanged, signOut } from 'firebase/auth';
+import { BrowserRouter as Router, Routes, Route, useNavigate } from 'react-router-dom';
+import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from './firebase';
 import PlayEditor from './PlayEditor';
 import PlayLibrary from './components/PlayLibrary';
 import PlaybookLibrary from './components/PlaybookLibrary';
 import SignInModal from './components/SignInModal';
-import logo from './assets/huddlup_logo_white_w_trans.png';
 import LandingPage from './LandingPage';
-import { Home, Book, BookOpen } from 'lucide-react';
+import NavBar from './components/NavBar.js';
 
 const AppContent = ({ user, openSignIn }) => {
 
   const [selectedPlay, setSelectedPlay] = useState(null);
   const navigate = useNavigate();
-  const location = useLocation();
 
   const handleLoadPlay = (play) => {
     setSelectedPlay(play);
@@ -23,62 +21,7 @@ const AppContent = ({ user, openSignIn }) => {
 
   return (
     <div className="min-h-screen flex flex-col bg-gray-900 text-white">
-      {/* Header */}
-      {location.pathname !== '/landing' && location.pathname !== '/' && (
-      <header className="w-full bg-gray-800">
-        <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
-          <div className="flex items-center space-x-3">
-            <img src={logo} alt="HuddlUp Logo" className="h-8" />
-            <h1 className="text-xl font-bold">Design. Huddle. Dominate.</h1>
-          </div>
-          <nav className="flex flex-wrap gap-2 items-center">
-            <Link
-              to="/"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
-            >
-              Home
-            </Link>
-            <Link
-              to="/editor"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
-            >
-              <Home className="w-4 h-4 mr-1" /> Editor
-            </Link>
-            <Link
-              to="/library"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
-            >
-              <Book className="w-4 h-4 mr-1" /> Play Library
-            </Link>
-            <Link
-              to="/playbooks"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
-            >
-              <BookOpen className="w-4 h-4 mr-1" /> Playbooks
-            </Link>
-            {user ? (
-              <>
-                <span className="mx-2 text-sm">{user.email}</span>
-                <button
-                  onClick={() => signOut(auth)}
-                  className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
-                >
-                  Sign Out
-                </button>
-              </>
-            ) : (
-              <button
-                onClick={openSignIn}
-                className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
-              >
-                Sign In
-              </button>
-            )}
-            </nav>
-
-        </div>
-      </header>
-      )}
+      <NavBar user={user} openSignIn={openSignIn} />
 
       {/* Main Content */}
       <main className="flex-grow">

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { signOut } from 'firebase/auth';
+import { Home, Book, BookOpen } from 'lucide-react';
+import { auth } from '../firebase';
+import logo from '../assets/huddlup_logo_white_w_trans.png';
+import { useTeamsContext } from '../context/TeamsContext.jsx';
+
+const NavBar = ({ user, openSignIn }) => {
+  const location = useLocation();
+  const { teams, selectedTeamId, setSelectedTeamId } = useTeamsContext();
+
+  const handleChange = (e) => {
+    setSelectedTeamId(e.target.value);
+  };
+
+  if (location.pathname === '/landing' || location.pathname === '/') {
+    return null;
+  }
+
+  return (
+    <header className="w-full bg-gray-800">
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
+        <div className="flex items-center space-x-3">
+          <img src={logo} alt="HuddlUp Logo" className="h-8" />
+          <h1 className="text-xl font-bold">Design. Huddle. Dominate.</h1>
+        </div>
+        <nav className="flex flex-wrap gap-2 items-center">
+          <Link
+            to="/"
+            className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+          >
+            Home
+          </Link>
+          <Link
+            to="/editor"
+            className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+          >
+            <Home className="w-4 h-4 mr-1" /> Editor
+          </Link>
+          <Link
+            to="/library"
+            className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+          >
+            <Book className="w-4 h-4 mr-1" /> Play Library
+          </Link>
+          <Link
+            to="/playbooks"
+            className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+          >
+            <BookOpen className="w-4 h-4 mr-1" /> Playbooks
+          </Link>
+          {teams.length > 0 && (
+            <select
+              value={selectedTeamId}
+              onChange={handleChange}
+              className="bg-gray-700 text-white px-2 py-1 rounded text-sm"
+            >
+              {teams.map((team) => (
+                <option key={team.id} value={team.id}>
+                  {team.teamName}
+                </option>
+              ))}
+            </select>
+          )}
+          {user ? (
+            <>
+              <span className="mx-2 text-sm">{user.email}</span>
+              <button
+                onClick={() => signOut(auth)}
+                className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              >
+                Sign Out
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={openSignIn}
+              className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+            >
+              Sign In
+            </button>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+export default NavBar;

--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -4,6 +4,7 @@ import { ChevronUp, ChevronDown, PlusCircle, Trash2 } from 'lucide-react';
 import PrintOptionsModal from './PrintOptionsModal';
 import { db, auth } from '../firebase';
 import { collection, getDocs, setDoc, doc, deleteDoc } from 'firebase/firestore';
+import { useTeamsContext } from '../context/TeamsContext.jsx';
 
 const PlaybookLibrary = ({ user, openSignIn }) => {
   const [playbooks, setPlaybooks] = useState([]);
@@ -12,6 +13,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
   const [printBookId, setPrintBookId] = useState(null);
   const [playsMap, setPlaysMap] = useState({});
   const [deleteId, setDeleteId] = useState(null);
+  const { teams, selectedTeamId } = useTeamsContext();
 
   useEffect(() => {
     const fetchBooks = async () => {
@@ -286,6 +288,13 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
     setPrintBookId(null);
   };
 
+  const selectedTeam = teams.find((t) => t.id === selectedTeamId);
+  const displayedPlaybooks = selectedTeam
+    ? playbooks.filter((pb) =>
+        selectedTeam.playbooks && selectedTeam.playbooks.includes(pb.id)
+      )
+    : playbooks;
+
   return (
     <div className="p-4 max-w-7xl mx-auto">
 
@@ -298,7 +307,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
           <PlusCircle className="w-4 h-4 mr-1" /> Add
         </button>
       </div>
-      {playbooks.map((book, bIndex) => (
+      {displayedPlaybooks.map((book, bIndex) => (
         <div key={book.id} className="mb-8 bg-gray-800 p-4 rounded">
           <div className="flex justify-between items-center mb-2">
 


### PR DESCRIPTION
## Summary
- create `NavBar.js` with dropdown listing teams
- use `NavBar` in `App` instead of inline header markup
- filter Playbook Library by selected team

## Testing
- `npm run lint`
- `npx jest` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848838e2c648324b8ab753f1fb0b3cb