### PR TITLE
Fix team save for signed-out users

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -114,7 +114,10 @@ const AppContent = ({ user, openSignIn }) => {
             path="/playbooks"
             element={<PlaybookLibrary user={user} openSignIn={openSignIn} />}
           />
-          <Route path="/teams" element={<TeamsPage />} />
+          <Route
+            path="/teams"
+            element={<TeamsPage user={user} openSignIn={openSignIn} />}
+          />
         </Routes>
       </main>
     </div>

--- a/src/pages/TeamsPage.jsx
+++ b/src/pages/TeamsPage.jsx
@@ -1,25 +1,45 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTeamsContext } from '../context/TeamsContext.jsx';
 import TeamFormModal from '../components/TeamFormModal.jsx';
 import ConfirmModal from '../components/ConfirmModal.jsx';
 
-const TeamsPage = () => {
+import { auth } from '../firebase';
+
+const TeamsPage = ({ user, openSignIn }) => {
   const { teams, createTeam, editTeam, deleteTeam } = useTeamsContext();
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState(null);
   const [deleteId, setDeleteId] = useState(null);
 
+  useEffect(() => {
+    if (!auth.currentUser) {
+      openSignIn && openSignIn();
+    }
+  }, [user]);
+
   const openCreate = () => {
+    if (!auth.currentUser) {
+      openSignIn && openSignIn();
+      return;
+    }
     setEditing(null);
     setShowForm(true);
   };
 
   const openEdit = (team) => {
+    if (!auth.currentUser) {
+      openSignIn && openSignIn();
+      return;
+    }
     setEditing(team);
     setShowForm(true);
   };
 
   const handleSave = async (data) => {
+    if (!auth.currentUser) {
+      openSignIn && openSignIn();
+      return;
+    }
     if (editing) {
       await editTeam(editing.id, data);
     } else {
@@ -29,6 +49,10 @@ const TeamsPage = () => {
   };
 
   const handleDelete = async () => {
+    if (!auth.currentUser) {
+      openSignIn && openSignIn();
+      return;
+    }
     if (deleteId) {
       await deleteTeam(deleteId);
       setDeleteId(null);


### PR DESCRIPTION
## Summary
- pass user and openSignIn props to TeamsPage
- prompt sign-in in TeamsPage before modifying teams

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848b426d34883248decc041e0304ce7