### PR TITLE
Fix team filtering for playbooks

### DIFF
--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -51,6 +51,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
     if (!selectedTeamId) return playbooks;
     const team = teams.find((t) => t.id === selectedTeamId);
     if (!team) return playbooks;
+    if (!team.playbooks || team.playbooks.length === 0) return playbooks;
     return playbooks.filter((pb) => (team.playbooks || []).includes(pb.id));
   }, [playbooks, selectedTeamId, teams]);
 


### PR DESCRIPTION
## Summary
- avoid hiding playbooks when a team is selected but has no playbooks assigned

## Testing
- `npm ci`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848b54ad7c08324b58a871f96d6bfd6