### PR TITLE
Improve print rendering timing

### DIFF
--- a/src/components/PrintOptionsModal.jsx
+++ b/src/components/PrintOptionsModal.jsx
@@ -22,8 +22,13 @@ const PrintOptionsModal = ({ onClose, onPrint }) => {
         playsPerPage: parseInt(playsPerPage, 10),
         includeTitle,
         includeNumber,
-                thicknessMultiplier: THICKNESS_MULTIPLIER,
+        thicknessMultiplier: THICKNESS_MULTIPLIER,
+      });
 
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          window.print();
+        });
       });
     }
   };


### PR DESCRIPTION
## Summary
- trigger browser print after rendering by adding double requestAnimationFrame

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848f490f9a48324ab915d9311d1e912