### PR TITLE
Implement print options modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Run `npm run setup` (or `npm ci`) to install all dependencies, then start the de
 
 Lint the project with `npm run lint`.
 
+## Print Options
+
+Use the `Print` button in the playbook library to open the `PrintOptionsModal`.
+Choose between wristband, playsheet or playbook layouts and configure play
+titles and numbers. The `PrintWrapper` component can be used to apply a
+`print-ready` class to the page before calling `window.print()` so that any
+`@media print` styles are applied.
+
 
 ## License
 

--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -208,12 +208,13 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
     const includeNumber = options.includeNumber !== false;
     const perPage = options.playsPerPage || plays.length;
     const isWrist = options.type === 'wristband';
+    const isBook = options.type === 'playbook';
     const layout = options.layout || 4;
 
 
     // wristband layouts are always two rows. Map the number of plays
     // (4/6/8) to the correct column count (2/3/4).
-    const columns = isWrist ? Math.ceil(layout / 2) : 4;
+    const columns = isWrist ? Math.ceil(layout / 2) : isBook ? 1 : 4;
 
     // Treat width/height as the final wristband dimensions. Each cell is
     // sized by dividing the overall width/height by the layout.
@@ -243,6 +244,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
 
                 .grid{display:grid;${isWrist ? `grid-template-columns:repeat(${columns}, ${cellWidth}in);grid-template-rows:repeat(2, ${cellHeight}in);width:${gridWidth}in;height:${gridHeight}in;margin:auto;gap:0;` : 'grid-template-columns:repeat(4,1fr);gap:4px;'}}
         .play{position:relative;border:1px solid #000;${isWrist ? `width:${cellWidth}in;height:${cellHeight}in;` : 'aspect-ratio:4/3;padding:2px;'}text-align:center;}
+        .notes{margin-top:8px;font-size:12px;text-align:left;}
         .label{position:absolute;top:0;left:0;display:flex;width:100%;z-index:1;}
                 .num{background:#000;color:#fff;padding:2px 4px;font-size:10px;display:flex;justify-content:center;align-items:center;}
         .title{background:#eee;color:#000;padding:2px 4px;font-size:10px;flex:1;display:flex;align-items:center;}
@@ -270,6 +272,27 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
         });
         w.document.write('</div>');
       }
+    } else if (isBook) {
+      plays.forEach((play, idx) => {
+        const num = idx + 1;
+        w.document.write('<div class="page">');
+        w.document.write('<div class="play">');
+        if (includeNumber || includeTitle) {
+          w.document.write('<div class="label">');
+          if (includeNumber) w.document.write(`<div class="num">${num}</div>`);
+          if (includeTitle) w.document.write(`<div class="title">${play.name}</div>`);
+          w.document.write('</div>');
+        }
+        if (play.displayImage) w.document.write(`<img src="${play.displayImage}" />`);
+        if (play.notes && play.notes.length) {
+          w.document.write('<ul class="notes">');
+          play.notes.forEach(n => {
+            if (n.text) w.document.write(`<li>${n.text}</li>`);
+          });
+          w.document.write('</ul>');
+        }
+        w.document.write('</div></div>');
+      });
     } else {
       for (let i = 0; i < plays.length; i += perPage) {
         w.document.write('<div class="grid page">');

--- a/src/components/PrintOptionsModal.jsx
+++ b/src/components/PrintOptionsModal.jsx
@@ -8,7 +8,7 @@ const PrintOptionsModal = ({ onClose, onPrint }) => {
   const [layout, setLayout] = useState('4');
   const [width, setWidth] = useState('4');
   const [height, setHeight] = useState('2');
-  const [playsPerPage, setPlaysPerPage] = useState('8');
+  const [playsPerPage, setPlaysPerPage] = useState('12');
   const [includeTitle, setIncludeTitle] = useState(true);
   const [includeNumber, setIncludeNumber] = useState(true);
 
@@ -56,8 +56,17 @@ const PrintOptionsModal = ({ onClose, onPrint }) => {
             />{' '}
             Play Sheets
           </label>
+          <label className="ml-4">
+            <input
+              type="radio"
+              value="playbook"
+              checked={type === 'playbook'}
+              onChange={() => setType('playbook')}
+            />{' '}
+            Playbook
+          </label>
         </div>
-        {type === 'wristband' ? (
+        {type === 'wristband' && (
           <>
             <div className="mb-2">
               <label className="block mb-1">Layout</label>
@@ -102,7 +111,9 @@ const PrintOptionsModal = ({ onClose, onPrint }) => {
               </div>
             </div>
           </>
-        ) : (
+        )}
+
+        {type === 'playsheet' && (
           <div className="mb-2">
             <label className="block mb-1">Plays Per Page</label>
             <select
@@ -110,13 +121,17 @@ const PrintOptionsModal = ({ onClose, onPrint }) => {
               onChange={(e) => setPlaysPerPage(e.target.value)}
               className="w-full p-1 rounded border"
             >
-              <option value="8">8</option>
               <option value="12">12</option>
-              <option value="16">16</option>
-              <option value="20">20</option>
+              <option value="18">18</option>
               <option value="24">24</option>
             </select>
           </div>
+        )}
+
+        {type === 'playbook' && (
+          <p className="mb-2 text-sm">
+            Each play will be printed on its own page with coaching notes.
+          </p>
         )}
         <div className="mb-2 flex gap-4">
           <label className="flex items-center">

--- a/src/components/PrintWrapper.jsx
+++ b/src/components/PrintWrapper.jsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react';
+
+const PrintWrapper = ({ printReady, children }) => {
+  useEffect(() => {
+    if (printReady) {
+      document.body.classList.add('print-ready');
+    } else {
+      document.body.classList.remove('print-ready');
+    }
+    return () => document.body.classList.remove('print-ready');
+  }, [printReady]);
+
+  return <div className={printReady ? 'print-ready' : ''}>{children}</div>;
+};
+
+export default PrintWrapper;


### PR DESCRIPTION
## Summary
- enhance PrintOptionsModal with playbook option
- allow playsheet per-page configuration
- add PrintWrapper utility
- extend print handler for playbook pages
- document basic print workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848f9283e4483248888a76db133bd28