### PR TITLE
Finalize print options flow

### DIFF
--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -201,8 +201,6 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
         }))
     );
 
-    const w = window.open('', '_blank');
-    if (!w) return;
 
     const includeTitle = options.includeTitle !== false;
     const includeNumber = options.includeNumber !== false;
@@ -241,18 +239,21 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
       <style>
         body{margin:0;padding:10px;font-family:sans-serif;}
         .page{page-break-after:always;margin-bottom:20px;}
-
-                .grid{display:grid;${isWrist ? `grid-template-columns:repeat(${columns}, ${cellWidth}in);grid-template-rows:repeat(2, ${cellHeight}in);width:${gridWidth}in;height:${gridHeight}in;margin:auto;gap:0;` : 'grid-template-columns:repeat(4,1fr);gap:4px;'}}
+        .grid{display:grid;${isWrist ? `grid-template-columns:repeat(${columns}, ${cellWidth}in);grid-template-rows:repeat(2, ${cellHeight}in);width:${gridWidth}in;height:${gridHeight}in;margin:auto;gap:0;` : 'grid-template-columns:repeat(4,1fr);gap:4px;'}}
         .play{position:relative;border:1px solid #000;${isWrist ? `width:${cellWidth}in;height:${cellHeight}in;` : 'aspect-ratio:4/3;padding:2px;'}text-align:center;}
         .notes{margin-top:8px;font-size:12px;text-align:left;}
         .label{position:absolute;top:0;left:0;display:flex;width:100%;z-index:1;}
-                .num{background:#000;color:#fff;padding:2px 4px;font-size:10px;display:flex;justify-content:center;align-items:center;}
+        .num{background:#000;color:#fff;padding:2px 4px;font-size:10px;display:flex;justify-content:center;align-items:center;}
         .title{background:#eee;color:#000;padding:2px 4px;font-size:10px;flex:1;display:flex;align-items:center;}
         img{width:100%;height:100%;object-fit:contain;display:block;image-rendering:pixelated;}
+        @media print { body{-webkit-print-color-adjust:exact;} }
       </style>
     `;
 
-    w.document.write(`<!doctype html><html><head><title>${book.name}</title>${style}</head><body>`);
+    const htmlStart = `<!doctype html><html><head><title>${book.name}</title>${style}</head><body>`;
+    const w = window.open('', '_blank');
+    if (!w) return;
+    w.document.write(htmlStart);
 
     if (isWrist) {
       for (let i = 0; i < plays.length; i += layout) {

--- a/src/components/PrintOptionsModal.jsx
+++ b/src/components/PrintOptionsModal.jsx
@@ -13,13 +13,28 @@ const PrintOptionsModal = ({ onClose, onPrint }) => {
   const [includeNumber, setIncludeNumber] = useState(true);
 
   const handleSubmit = () => {
+    const layoutNum = parseInt(layout, 10);
+    const widthNum = parseFloat(width);
+    const heightNum = parseFloat(height);
+    const perPageNum = parseInt(playsPerPage, 10);
+
+    if (
+      Number.isNaN(layoutNum) ||
+      Number.isNaN(widthNum) ||
+      Number.isNaN(heightNum) ||
+      Number.isNaN(perPageNum)
+    ) {
+      alert('Please enter valid numeric values.');
+      return;
+    }
+
     if (onPrint) {
       onPrint({
         type,
-        layout: parseInt(layout, 10),
-        width: parseFloat(width),
-        height: parseFloat(height),
-        playsPerPage: parseInt(playsPerPage, 10),
+        layout: layoutNum,
+        width: widthNum,
+        height: heightNum,
+        playsPerPage: perPageNum,
         includeTitle,
         includeNumber,
         thicknessMultiplier: THICKNESS_MULTIPLIER,

--- a/src/components/PrintOptionsModal.test.jsx
+++ b/src/components/PrintOptionsModal.test.jsx
@@ -1,0 +1,24 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import PrintOptionsModal, { THICKNESS_MULTIPLIER } from './PrintOptionsModal';
+
+test('PrintOptionsModal calls onPrint with parsed options', () => {
+  const onPrint = jest.fn();
+  window.print = jest.fn();
+  jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => cb());
+
+  render(<PrintOptionsModal onClose={() => {}} onPrint={onPrint} />);
+
+  fireEvent.click(screen.getByText('Print'));
+
+  expect(onPrint).toHaveBeenCalledWith({
+    type: 'wristband',
+    layout: 4,
+    width: 4,
+    height: 2,
+    playsPerPage: 12,
+    includeTitle: true,
+    includeNumber: true,
+    thicknessMultiplier: THICKNESS_MULTIPLIER,
+  });
+  expect(window.print).toHaveBeenCalled();
+});

--- a/src/components/PrintWrapper.jsx
+++ b/src/components/PrintWrapper.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 
 const PrintWrapper = ({ printReady, children }) => {
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (printReady) {
       document.body.classList.add('print-ready');
     } else {

--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,21 @@
   );
   background-size: 20px 20px;
 }
+
+/* Print styling */
+.no-print {
+  display: none !important;
+}
+
+@media print {
+  header,
+  .modal,
+  .no-print {
+    display: none !important;
+  }
+
+  body.print-ready {
+    margin: 0;
+    padding: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add print CSS rules
- validate form values in `PrintOptionsModal` and double requestAnimationFrame
- consolidate layout logic in `PlaybookLibrary` before opening window
- ensure `PrintWrapper` uses `useLayoutEffect`
- test `PrintOptionsModal` print callback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6848fc604b648324aeedd6a498199634