### PR TITLE
Update brand references and landing content

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>HuddlUp</title>
+    <title>huddlup</title>
     <!-- ✅ Link to Tailwind CSS -->
     <link rel="stylesheet" href="/src/index.css" />
   </head>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,7 +32,7 @@ const AppContent = ({ user, openSignIn }) => {
       <header className="w-full bg-gray-800">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
           <div className="flex items-center space-x-3">
-            <img src={logo} alt="HuddlUp Logo" className="h-8" />
+            <img src={logo} alt="huddlup logo" className="h-8" />
             <h1 className="text-xl font-bold">Design. Huddle. Dominate.</h1>
           </div>
           <nav className="flex flex-wrap gap-2 items-center">

--- a/src/LandingPage.jsx
+++ b/src/LandingPage.jsx
@@ -11,7 +11,7 @@ const LandingPage = () => {
       <header className="w-full bg-gray-800">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
           <div className="flex items-center space-x-3">
-            <img src={logo} alt="HuddlUp Logo" className="h-8" />
+          <img src={logo} alt="huddlup logo" className="h-8" />
             <h1 className="text-xl font-bold">Flag Football Play Designer</h1>
           </div>
           <Link
@@ -33,7 +33,6 @@ const LandingPage = () => {
         }}
       >
         <img src={playImage} alt="Play Design" className="max-w-md mb-6 z-10" />
-        <h2 className="text-4xl font-bold mb-4">Design. Huddle. Dominate.</h2>
         <Link
           to="/editor"
           className="bg-[#7AC142] text-black px-6 py-3 rounded font-semibold hover:bg-[#002A5C] hover:text-white transition-colors z-10"
@@ -62,7 +61,7 @@ const LandingPage = () => {
 
       {/* Footer */}
       <footer className="bg-gray-800 text-[#B2B7BB] text-center py-4 mt-auto">
-        &copy; 2024 HuddlUp
+        &copy; 2024 huddlup
       </footer>
     </div>
   );

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -22,7 +22,7 @@ const NavBar = ({ user, openSignIn }) => {
     <header className="w-full bg-gray-800">
       <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
         <div className="flex items-center space-x-3">
-          <img src={logo} alt="HuddlUp Logo" className="h-8" />
+          <img src={logo} alt="huddlup logo" className="h-8" />
           <h1 className="text-xl font-bold">Design. Huddle. Dominate.</h1>
         </div>
         <nav className="flex flex-wrap gap-2 items-center">

--- a/src/components/SignInModal.jsx
+++ b/src/components/SignInModal.jsx
@@ -38,7 +38,7 @@ const SignInModal = ({ onClose }) => {
           <X className="w-5 h-5" />
         </button>
         <div className="text-center mb-4">
-          <img src={logo} alt="HuddlUp Logo" className="h-10 mx-auto" />
+          <img src={logo} alt="huddlup logo" className="h-10 mx-auto" />
         </div>
         {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
         <form onSubmit={handleSubmit} className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- standardize brand name to `huddlup`
- remove "Design. Huddle. Dominate." tagline from the home page hero section

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684908a6075c83248412447ca50973cb