### PR TITLE
Add team playbook linking

### DIFF
--- a/src/components/TeamPlaybooksModal.jsx
+++ b/src/components/TeamPlaybooksModal.jsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { db, auth } from '../firebase';
+import { collection, getDocs } from 'firebase/firestore';
+import { useTeamsContext } from '../context/TeamsContext.jsx';
+
+const TeamPlaybooksModal = ({ team, onClose }) => {
+  const { editTeam } = useTeamsContext();
+  const [playbooks, setPlaybooks] = useState([]);
+  const [selectedIds, setSelectedIds] = useState(team.playbooks || []);
+
+  useEffect(() => {
+    const fetchBooks = async () => {
+      if (auth.currentUser) {
+        const snap = await getDocs(
+          collection(db, 'users', auth.currentUser.uid, 'playbooks')
+        );
+        const arr = [];
+        snap.forEach((d) => arr.push(d.data()));
+        setPlaybooks(arr);
+      } else {
+        const arr = [];
+        for (const key in localStorage) {
+          if (key.startsWith('Playbook-')) {
+            try {
+              const book = JSON.parse(localStorage.getItem(key));
+              arr.push(book);
+            } catch {
+              // ignore bad data
+            }
+          }
+        }
+        setPlaybooks(arr);
+      }
+    };
+    fetchBooks();
+  }, []);
+
+  const toggle = (id) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((pid) => pid !== id) : [...prev, id]
+    );
+  };
+
+  const handleSave = async () => {
+    await editTeam(team.id, { playbooks: selectedIds });
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white text-black rounded p-4 w-full max-w-sm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-bold mb-2">Team Playbooks</h2>
+        <div className="max-h-64 overflow-y-auto mb-2">
+          {playbooks.map((pb) => (
+            <label key={pb.id} className="flex items-center gap-2 mb-1">
+              <input
+                type="checkbox"
+                checked={selectedIds.includes(pb.id)}
+                onChange={() => toggle(pb.id)}
+              />
+              {pb.name}
+            </label>
+          ))}
+          {playbooks.length === 0 && (
+            <div className="text-sm text-center">No playbooks found.</div>
+          )}
+        </div>
+        <div className="flex justify-end gap-2 mt-2">
+          <button onClick={onClose} className="px-3 py-1 rounded bg-gray-300">
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-3 py-1 rounded bg-blue-600 text-white"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TeamPlaybooksModal;

--- a/src/components/TeamPlaybooksModal.test.jsx
+++ b/src/components/TeamPlaybooksModal.test.jsx
@@ -1,0 +1,30 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import TeamPlaybooksModal from './TeamPlaybooksModal';
+import * as TeamsContext from '../context/TeamsContext.jsx';
+
+jest.mock('../context/TeamsContext.jsx');
+jest.mock('../firebase', () => ({ db: {}, auth: {} }));
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  getDocs: jest.fn(async () => ({ forEach: () => {} })),
+}));
+
+test('TeamPlaybooksModal saves selected playbooks', async () => {
+  localStorage.setItem(
+    'Playbook-1',
+    JSON.stringify({ id: 'Playbook-1', name: 'PB1', playIds: [] })
+  );
+  const editTeam = jest.fn();
+  TeamsContext.useTeamsContext.mockReturnValue({ editTeam });
+
+  const team = { id: 'team1', playbooks: [] };
+  render(<TeamPlaybooksModal team={team} onClose={() => {}} />);
+
+  const checkbox = await screen.findByLabelText('PB1');
+  fireEvent.click(checkbox);
+  fireEvent.click(screen.getByText('Save'));
+
+  await waitFor(() => expect(editTeam).toHaveBeenCalledWith('team1', { playbooks: ['Playbook-1'] }));
+
+  localStorage.clear();
+});

--- a/src/pages/TeamsPage.jsx
+++ b/src/pages/TeamsPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useTeamsContext } from '../context/TeamsContext.jsx';
 import TeamFormModal from '../components/TeamFormModal.jsx';
 import ConfirmModal from '../components/ConfirmModal.jsx';
+import TeamPlaybooksModal from '../components/TeamPlaybooksModal.jsx';
 
 import { auth } from '../firebase';
 
@@ -10,6 +11,7 @@ const TeamsPage = ({ user, openSignIn }) => {
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState(null);
   const [deleteId, setDeleteId] = useState(null);
+  const [playbookTeam, setPlaybookTeam] = useState(null);
 
   useEffect(() => {
     if (!auth.currentUser) {
@@ -33,6 +35,14 @@ const TeamsPage = ({ user, openSignIn }) => {
     }
     setEditing(team);
     setShowForm(true);
+  };
+
+  const openPlaybooks = (team) => {
+    if (!auth.currentUser) {
+      openSignIn && openSignIn();
+      return;
+    }
+    setPlaybookTeam(team);
   };
 
   const handleSave = async (data) => {
@@ -83,6 +93,12 @@ const TeamsPage = ({ user, openSignIn }) => {
               Edit
             </button>
             <button
+              onClick={() => openPlaybooks(team)}
+              className="bg-green-600 hover:bg-green-500 px-2 py-1 rounded text-sm"
+            >
+              Playbooks
+            </button>
+            <button
               onClick={() => setDeleteId(team.id)}
               className="bg-red-600 hover:bg-red-500 px-2 py-1 rounded text-sm"
             >
@@ -105,6 +121,12 @@ const TeamsPage = ({ user, openSignIn }) => {
           onCancel={() => setDeleteId(null)}
           onConfirm={handleDelete}
           confirmText="Delete"
+        />
+      )}
+      {playbookTeam && (
+        <TeamPlaybooksModal
+          team={playbookTeam}
+          onClose={() => setPlaybookTeam(null)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- create `TeamPlaybooksModal` to attach playbooks to teams
- open the modal from the Teams page using a new Playbooks button
- test the modal's save behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684908deea9483248a3033de08f11518