### PR TITLE
Add playbook locking and team save

### DIFF
--- a/src/context/TeamsContext.jsx
+++ b/src/context/TeamsContext.jsx
@@ -47,9 +47,13 @@ export const TeamsContextProvider = ({ children }) => {
     return team;
   };
 
-  const editTeam = async (teamId, { teamName, logoFile }) => {
+  const editTeam = async (
+    teamId,
+    { teamName, logoFile, playbooks } = {}
+  ) => {
     const updates = {};
     if (teamName !== undefined) updates.teamName = teamName;
+    if (playbooks !== undefined) updates.playbooks = playbooks;
     if (logoFile) {
       const url = await uploadTeamLogo(teamId, logoFile);
       updates.teamLogoUrl = url;


### PR DESCRIPTION
## Summary
- allow editing teams with playbook assignments
- add lock/unlock support for playbooks and locking UI
- prevent editing locked playbooks

## Testing
- `npm ci`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684985b9783c8324924fb4790622a628