### PR TITLE
Fix collapsed playbook sections

### DIFF
--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -52,6 +52,14 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
     fetchBooks();
   }, [user]);
 
+  useEffect(() => {
+    const obj = {};
+    playbooks.forEach((pb) => {
+      obj[pb.id] = false;
+    });
+    setCollapsed(obj);
+  }, [playbooks]);
+
   const displayedPlaybooks = useMemo(() => {
     if (!selectedTeamId) return playbooks;
     const team = teams.find((t) => t.id === selectedTeamId);


### PR DESCRIPTION
## Summary
- ensure playbook sections are always expanded by initializing collapse state

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_684a520bfeec83249aae3fccc697ff61