### PR TITLE
Add site owner play access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
 VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 VITE_FIREBASE_APP_ID=your_app_id
 VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
+VITE_SITE_OWNER_EMAIL=owner@example.com

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ const AppContent = ({ user, openSignIn }) => {
   const [selectedPlay, setSelectedPlay] = useState(null);
   const navigate = useNavigate();
   const location = useLocation();
+  const isAdmin = user?.email === import.meta.env.VITE_SITE_OWNER_EMAIL;
 
   const handleLoadPlay = (play) => {
     setSelectedPlay(play);
@@ -66,6 +67,14 @@ const AppContent = ({ user, openSignIn }) => {
             >
               <Users className="w-4 h-4 mr-1" /> Teams
             </Link>
+            {isAdmin && (
+              <Link
+                to="/all-plays"
+                className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              >
+                <LibraryBig className="w-4 h-4 mr-1" /> All Plays
+              </Link>
+            )}
             {user ? (
               <>
                 <span className="mx-2 text-sm">{user.email}</span>
@@ -118,6 +127,19 @@ const AppContent = ({ user, openSignIn }) => {
             path="/teams"
             element={<TeamsPage user={user} openSignIn={openSignIn} />}
           />
+          {isAdmin && (
+            <Route
+              path="/all-plays"
+              element={
+                <PlayLibrary
+                  onSelectPlay={handleLoadPlay}
+                  user={user}
+                  openSignIn={openSignIn}
+                  adminMode
+                />
+              }
+            />
+          )}
         </Routes>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- allow the site owner to browse all plays from every user via Firestore `collectionGroup`
- expose the owner email in `.env.example`
- show an **All Plays** link and route when signed in as the owner
- display user IDs on each play card in admin mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abe5ffd3c8324aebb10e7d5541215