### PR TITLE
Adjust nav layout and update All Plays icon

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ import PlaybookLibrary from './components/PlaybookLibrary';
 import SignInModal from './components/SignInModal';
 import LandingPage from './LandingPage';
 
-import { House, LibraryBig, LogOut, BookOpen, Users } from 'lucide-react';
+import { House, LibraryBig, LogOut, BookOpen, Users, Globe } from 'lucide-react';
 import TeamsPage from './pages/TeamsPage.jsx';
 import logo from './assets/huddlup_logo_white_w_trans.png';
 
@@ -31,12 +31,12 @@ const AppContent = ({ user, openSignIn }) => {
       {/* Header */}
       {location.pathname !== '/landing' && location.pathname !== '/' && (
       <header className="w-full bg-gray-800">
-        <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
+        <div className="w-full flex items-center justify-between px-4 py-2">
           <div className="flex items-center space-x-3">
             <img src={logo} alt="huddlup logo" className="h-8" />
             <h1 className="text-xl font-bold">Design. Huddle. Dominate.</h1>
           </div>
-          <nav className="flex flex-wrap gap-2 items-center">
+          <nav className="flex flex-nowrap gap-2 items-center">
             <Link
               to="/"
               className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
@@ -72,7 +72,7 @@ const AppContent = ({ user, openSignIn }) => {
                 to="/all-plays"
                 className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
               >
-                <LibraryBig className="w-4 h-4 mr-1" /> All Plays
+                <Globe className="w-4 h-4 mr-1" /> All Plays
               </Link>
             )}
             {user ? (

--- a/src/LandingPage.jsx
+++ b/src/LandingPage.jsx
@@ -9,7 +9,7 @@ const LandingPage = () => {
     <div className="min-h-screen flex flex-col bg-black text-white">
       {/* Header */}
       <header className="w-full bg-gray-800">
-        <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
+        <div className="w-full flex items-center justify-between px-4 py-2">
           <div className="flex items-center space-x-3">
           <img src={logo} alt="huddlup logo" className="h-8" />
             <h1 className="text-xl font-bold">Flag Football Play Designer</h1>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -21,12 +21,12 @@ const NavBar = ({ user, openSignIn }) => {
 
   return (
     <header className="w-full bg-gray-800">
-      <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
+      <div className="w-full flex items-center justify-between px-4 py-2">
         <div className="flex items-center space-x-3">
           <img src={logo} alt="huddlup logo" className="h-8" />
           <h1 className="text-xl font-bold">Design. Huddle. Dominate.</h1>
         </div>
-        <nav className="flex flex-wrap gap-2 items-center">
+        <nav className="flex flex-nowrap gap-2 items-center">
           <Link
             to="/"
             className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"


### PR DESCRIPTION
## Summary
- use lucide `Globe` for the **All Plays** link
- allow header containers to span the full width
- keep nav buttons on one line

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684accd8f26483249df8aaf8ab00bee6