### PR TITLE
Fix Canvas event casing

### DIFF
--- a/src/components/Canvas.jsx
+++ b/src/components/Canvas.jsx
@@ -33,8 +33,8 @@ const Canvas = () => {
       width={800}
       height={600}
       onMouseDown={handleMouseDown}
-      onMousemove={handleMouseMove}
-      onMouseup={handleMouseUp}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
       style={{ background: '#ffffff', border: '1px solid #ccc' }}
     >
       <Layer>


### PR DESCRIPTION
## Summary
- fix mouse event prop casing in `Canvas` so events register

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684ad267357c83249013c104279c40f1