### PR TITLE
Add touch support to FootballField

### DIFF
--- a/src/components/FootballField.jsx
+++ b/src/components/FootballField.jsx
@@ -234,7 +234,11 @@ const FootballField = ({
   };
 
   return (
-    <div ref={containerRef} className="w-full overflow-x-auto">
+    <div
+      ref={containerRef}
+      className="w-full overflow-x-auto"
+      style={{ touchAction: 'none' }}
+    >
     <Stage
       ref={localStageRef}
       width={width}
@@ -242,7 +246,12 @@ const FootballField = ({
       scaleX={scale}
       scaleY={scale}
       className="bg-white border border-gray-300"
-      onClick={handleStageClick}
+      onPointerDown={(e) => {
+        if (e.evt.pointerType !== 'touch') handleStageClick(e);
+      }}
+      onPointerUp={(e) => {
+        if (e.evt.pointerType === 'touch') handleStageClick(e);
+      }}
     >
       <Layer ref={layerRef}>
         {/* Field Lines */}


### PR DESCRIPTION
## Summary
- handle taps and drags on touchscreen devices
- block default scrolling inside the drawing stage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad27cf2cc83248c6527292903cae6