### PR TITLE
Improve iOS detection

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -11,6 +11,7 @@ import LoadingSpinner from "./components/LoadingSpinner";
 import { User, ArrowRight, Trash2, StickyNote } from "lucide-react";
 import huddlupLogo from "./assets/huddlup_logo_2.svg";
 import { THICKNESS_MULTIPLIER } from "./components/PrintOptionsModal";
+import isIOS from "./utils/isIOS";
 
 const width = 800;
 const height = 600;
@@ -572,7 +573,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
     });
   };
 
-  const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const isIos = isIOS();
 
   const handleExport = async (ratio) => {
     const url = await getExportDataUrl(ratio);

--- a/src/utils/isIOS.js
+++ b/src/utils/isIOS.js
@@ -1,0 +1,7 @@
+export default function isIOS() {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  const iOS = /iPad|iPhone|iPod/.test(ua);
+  const iPadDesktop = ua.includes('Mac') && navigator.maxTouchPoints > 1;
+  return iOS || iPadDesktop;
+}

--- a/src/utils/isIOS.test.js
+++ b/src/utils/isIOS.test.js
@@ -1,0 +1,19 @@
+import isIOS from './isIOS';
+
+describe('isIOS helper', () => {
+  const originalUA = navigator.userAgent;
+  const originalMTP = navigator.maxTouchPoints;
+
+  afterEach(() => {
+    Object.defineProperty(window.navigator, 'userAgent', { value: originalUA, configurable: true });
+    Object.defineProperty(window.navigator, 'maxTouchPoints', { value: originalMTP, configurable: true });
+  });
+
+  test('detects iPadOS desktop-style UA', () => {
+    const ipadOSUA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15';
+    Object.defineProperty(window.navigator, 'userAgent', { value: ipadOSUA, configurable: true });
+    Object.defineProperty(window.navigator, 'maxTouchPoints', { value: 5, configurable: true });
+
+    expect(isIOS()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize iOS detection with an `isIOS` helper
- use updated logic that handles iPad desktop UAs
- test helper against an iPadOS 16 user-agent
- refactor PlayEditor to use the helper

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token in src/App.jsx)*
- `npx jest src/utils/isIOS.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684ad638e5d4832496d828711af64bb5