### PR TITLE
Fix canvas scale for mobile

### DIFF
--- a/src/components/FootballField.jsx
+++ b/src/components/FootballField.jsx
@@ -245,6 +245,7 @@ const FootballField = ({
       height={height}
       scaleX={scale}
       scaleY={scale}
+      style={{ width: width * scale, height: height * scale }}
       className="bg-white border border-gray-300"
       onPointerDown={(e) => {
         if (e.evt.pointerType !== 'touch') handleStageClick(e);


### PR DESCRIPTION
## Summary
- scale canvas element visually to prevent horizontal scroll on narrow screens

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b603268c0832499007964cbdc5b1b